### PR TITLE
HOTFIX - Player State

### DIFF
--- a/lib/src/controllers/pod_base_controller.dart
+++ b/lib/src/controllers/pod_base_controller.dart
@@ -79,8 +79,14 @@ class _PodBaseController extends GetxController {
   //   );
   // }
   void _listenToVideoState() {
-    // Handle the loading state
-    if (_videoCtr!.value.isBuffering || !_videoCtr!.value.isInitialized) {
+    // Handle the uninitialized state
+    if (!_videoCtr!.value.isInitialized) {
+      podVideoStateChanger(PodVideoState.loading);
+      return;
+    }
+
+    // Handle the buffering state
+    if (!_videoCtr!.value.isPlaying && _videoCtr!.value.isBuffering) {
       podVideoStateChanger(PodVideoState.loading);
       return;
     }


### PR DESCRIPTION
Fixing logic for the loading state.

### The Issue
After playing a video for some minutes, it can start buffering again.
When this happens, the state of the PodPlayer is changed to "loading", and a loading indicator appears on top of the video.

The problem is that we may be buffering while still playing. In this situation, we don't want to present a loading indicator in the UI.

---

### The fix
When buffering, I check if the player is currently playing or not before setting a "loading" state.

With this fix, the loading indicator only becomes visible if the player gets paused (waiting for the buffering). As soon as it starts to play, the loading indicator disappears.