### PR TITLE
Option to disable keyboard shortcuts

### DIFF
--- a/lib/src/controllers/pod_getx_video_controller.dart
+++ b/lib/src/controllers/pod_getx_video_controller.dart
@@ -207,6 +207,11 @@ class PodGetXVideoController extends _PodGesturesController {
     required String tag,
   }) {
     if (kIsWeb) {
+      // If keyboard shortcuts are disabled, don't handle any keyboard events
+      if (podPlayerConfig.disableKeyboardShortcuts) {
+        return;
+      }
+
       if (event.isKeyPressed(LogicalKeyboardKey.space)) {
         togglePlayPauseVideo();
         return;

--- a/lib/src/models/pod_player_config.dart
+++ b/lib/src/models/pod_player_config.dart
@@ -4,6 +4,11 @@ class PodPlayerConfig {
   final bool forcedVideoFocus;
   final bool wakelockEnabled;
 
+  /// Disable keyboard shortcuts on web (Space, M, F, Esc, Arrow keys).
+  /// When true, keyboard shortcuts are disabled to prevent interference with form inputs.
+  /// Default value is true (shortcuts disabled).
+  final bool disableKeyboardShortcuts;
+
   /// Initial video quality priority. The first available option will be used,
   /// from start to the end of this list. If all options informed are not
   /// available or if nothing is provided, 360p is used.
@@ -16,6 +21,7 @@ class PodPlayerConfig {
     this.isLooping = false,
     this.forcedVideoFocus = false,
     this.wakelockEnabled = true,
+    this.disableKeyboardShortcuts = true,
     this.videoQualityPriority = const [1080, 720, 360],
   });
 
@@ -24,6 +30,7 @@ class PodPlayerConfig {
     bool? isLooping,
     bool? forcedVideoFocus,
     bool? wakelockEnabled,
+    bool? disableKeyboardShortcuts,
     List<int>? videoQualityPriority,
   }) {
     return PodPlayerConfig(
@@ -31,6 +38,7 @@ class PodPlayerConfig {
       isLooping: isLooping ?? this.isLooping,
       forcedVideoFocus: forcedVideoFocus ?? this.forcedVideoFocus,
       wakelockEnabled: wakelockEnabled ?? this.wakelockEnabled,
+      disableKeyboardShortcuts: disableKeyboardShortcuts ?? this.disableKeyboardShortcuts,
       videoQualityPriority: videoQualityPriority ?? this.videoQualityPriority,
     );
   }


### PR DESCRIPTION
Disabling keyboard shortcuts by default on the video player.

Video players that were playing a preview of microlessons were capturing these shortcuts and behaving badly on WEB ( like, entering fullscreen mode out of nowhere).

We'll be disabling these shortcuts by default, but allowing us to turn them on when we need.